### PR TITLE
fix: when street number isNaN, rm it

### DIFF
--- a/src/InputAddress/InputAddress.tsx
+++ b/src/InputAddress/InputAddress.tsx
@@ -169,7 +169,11 @@ const InputAddress = (props: InputAddressProps) => {
         formattedAddress.street = component.long_name;
       }
       if (component.types.includes("street_number")) {
-        formattedAddress.streetNumber = component.long_name;
+        //In some cases, the street number is a string (e.g. 'Sur'), so check if the conversion is a number
+        const streetNumber = component.long_name;
+
+        if (isNaN(Number(streetNumber))) formattedAddress.streetNumber = "0";
+        else formattedAddress.streetNumber = component.long_name;
       }
       if (component.types.includes("locality")) {
         const isCABA = component.short_name === "CABA";


### PR DESCRIPTION
BUG: un cliente pone 'San Antonio Sur' y googleplaces el street number lo completa con 'Sur'. Asi que puse una validacion para esto

"addresses":[{"street":"San Antonio","number":"Sur","zipCode":"E2840","city":"Gualeguay","state":"Entre Ríos","country":"Argentina","municipality":"Gualeguay"}]}

Sentry: https://allariamas.sentry.io/issues/5964573913/events/160d8784f5b14b509475b80696d15fc6/?project=4508042298851328